### PR TITLE
fix: projects grid and certifications badge in mobile

### DIFF
--- a/src/components/bento-grid-item.tsx
+++ b/src/components/bento-grid-item.tsx
@@ -39,7 +39,7 @@ export default function BentoGridItem({
       whileHover={"hover"}
       whileTap={"hover"}
       className={cn(
-        "border-border relative flex flex-col justify-between overflow-clip rounded-xl border sm:max-lg:min-h-80",
+        "border-border relative flex flex-col justify-between overflow-clip rounded-xl border min-h-80",
         className,
       )}
     >

--- a/src/components/tilted-card.tsx
+++ b/src/components/tilted-card.tsx
@@ -12,7 +12,6 @@ interface TiltedCardProps {
   imageWidth?: React.CSSProperties["width"];
   scaleOnHover?: number;
   rotateAmplitude?: number;
-  showMobileWarning?: boolean;
   overlayContent?: React.ReactNode;
   displayOverlayContent?: boolean;
 }
@@ -30,7 +29,6 @@ export default function TiltedCard({
   imageWidth = "300px",
   scaleOnHover = 1.1,
   rotateAmplitude = 14,
-  showMobileWarning = true,
   overlayContent = null,
   displayOverlayContent = false,
 }: TiltedCardProps) {
@@ -91,12 +89,6 @@ export default function TiltedCard({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {showMobileWarning && (
-        <div className="absolute top-4 block text-center text-sm sm:hidden">
-          This effect is not optimized for mobile. Check on desktop.
-        </div>
-      )}
-
       <motion.div
         className="relative [transform-style:preserve-3d]"
         style={{


### PR DESCRIPTION
This pull request makes minor adjustments to the `TiltedCard` and `BentoGridItem` components, primarily by removing the mobile warning feature from `TiltedCard` and simplifying class names for layout consistency.

Component cleanup and feature removal:

* Removed the `showMobileWarning` prop, its default value, and the associated warning message from the `TiltedCard` component, streamlining its interface and display. [[1]](diffhunk://#diff-4274244115d511a10aaa49a44f5114ddde8b76f300999939db4ecf247dd5d3edL15) [[2]](diffhunk://#diff-4274244115d511a10aaa49a44f5114ddde8b76f300999939db4ecf247dd5d3edL33) [[3]](diffhunk://#diff-4274244115d511a10aaa49a44f5114ddde8b76f300999939db4ecf247dd5d3edL94-L99)

Layout consistency:

* Updated the `BentoGridItem` component to always apply the `min-h-80` class, ensuring a consistent minimum height across screen sizes.