### PR TITLE
fix: use absolute URL in JSON-LD and canonical link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        <link rel="canonical" href="https://luanroger.dev/" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/src/constants/json-ld.ts
+++ b/src/constants/json-ld.ts
@@ -1,12 +1,13 @@
 export const jsonLd = {
   "@context": "https://schema.org",
   "@type": "Person",
+  "@id": "https://luanroger.dev",
   name: "Luan Roger",
-  url: "https://www.luanroger.dev",
-  image: "/images/lr-profile.jpg",
+  url: "https://luanroger.dev",
+  image: "https://luanroger.dev/images/lr-logo.png",
   sameAs: [
     "https://github.com/LuanRoger",
-    "https://linkedin.com/in/luan-roger",
+    "https://www.linkedin.com/in/luan-roger",
     "https://blog.luanroger.dev",
   ],
   jobTitle: "Software Engineer",
@@ -14,6 +15,7 @@ export const jsonLd = {
     "@type": "Organization",
     name: "Aramis",
     url: "https://www.aramis.com.br",
+    sameAs: "https://www.aramis.com.br",
   },
   description:
     "I'm Luan Roger, a software engineer and full-stack developer. I build web apps, APIs, and open-source tools.",


### PR DESCRIPTION
This pull request focuses on improving SEO and structured data for the site by updating the canonical URL, enhancing the JSON-LD schema, and correcting some profile links and image references.

SEO and canonical URL improvements:
* Added a `<link rel="canonical">` tag in the `RootLayout` component to explicitly set the canonical URL to `https://luanroger.dev/`.

Structured data (JSON-LD) enhancements:
* Added the `@id` property to the JSON-LD schema to uniquely identify the person entity.
* Updated the `url` and `image` fields to use the correct domain and a full image URL, improving consistency and crawlability.
* Corrected the LinkedIn profile link to include `www`, and updated the `sameAs` property for the employer organization.